### PR TITLE
update get_keycodes.sh for Linux >= 4.4

### DIFF
--- a/key/get_keycodes.sh
+++ b/key/get_keycodes.sh
@@ -5,14 +5,26 @@
 #  Project home:  <https://github.com/galaktor/gostwriter>
 #  Licensed under The GPL v3 License (see README and LICENSE files)
 
-inputh="/usr/include/linux/input.h"
+inputh="/usr/include/linux/input-event-codes.h"
 
 if [[ $# -ne 0 ]]
 then
   inputh=$1
+elif test -f /usr/include/linux/input-event-codes.h
+then
+  # Linux >= 4.4 factored input-event-codes.h out of input.h
+  inputh=/usr/include/linux/input-event-codes.h
+elif test -f /usr/include/linux/input.h
+then
+  inputh=/usr/include/linux/input.h
+else
+  echo "no input header found; use ./get_keycodes_kerneltip.sh"
+  echo "or install /usr/include/linux headers (e.g. debian: linux-libc-dev;"
+  echo "arch linux: linux-api-headers)"
+  exit 1
 fi
 
-echo "using KEYS from input.h at: $inputh"
+echo "using KEYS from file at: $inputh"
 rm ./codes.go
 cp ./codes.template ./codes.go
 codes=$(cat $inputh | grep -e KEY_ | sed "s/KEY_//" | awk '{printf("    CODE_%-21s \\\= Code\\\(C\\\.KEY_%-23s\\\)  \\\/\\\* %-5s \\\*\\\/\\n", $2, $2, $3)}')  # have to escape it all for sed...madness

--- a/key/get_keycodes_kerneltip.sh
+++ b/key/get_keycodes_kerneltip.sh
@@ -5,5 +5,5 @@
 #  Project home:  <https://github.com/galaktor/gostwriter>
 #  Licensed under The GPL v3 License (see README and LICENSE files)
 
-curl https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input.h > /tmp/input.h
-./get_keycodes.sh /tmp/input.h
+curl https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input-event-codes.h > /tmp/input-event-codes.h
+./get_keycodes.sh /tmp/input-event-codes.h


### PR DESCRIPTION
In linux >= 4.4, the KEY_* definitions are no longer in input.h but in input-event-codes.h.